### PR TITLE
이벤트 생성 및 API 개발

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
             <artifactId>spring-restdocs-mockmvc</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/pl.pragmatists/JUnitParams -->
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>modelmapper</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,16 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.1</version>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/springrestapi/SpringRestapiApplication.java
+++ b/src/main/java/com/example/springrestapi/SpringRestapiApplication.java
@@ -1,13 +1,20 @@
 package com.example.springrestapi;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class SpringRestapiApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(SpringRestapiApplication.class, args);
+    }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
     }
 
 }

--- a/src/main/java/com/example/springrestapi/common/ErrorSerializer.java
+++ b/src/main/java/com/example/springrestapi/common/ErrorSerializer.java
@@ -1,0 +1,48 @@
+package com.example.springrestapi.common;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.validation.Errors;
+
+import java.io.IOException;
+
+@JsonComponent
+public class ErrorSerializer extends JsonSerializer<Errors> {
+
+    @Override
+    public void serialize(Errors errors, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartArray();
+        errors.getFieldErrors().forEach(e -> {
+            try {
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeStringField("field", e.getField());
+                jsonGenerator.writeStringField("objectName", e.getObjectName());
+                jsonGenerator.writeStringField("code", e.getCode());
+                jsonGenerator.writeStringField("defaultMessage", e.getDefaultMessage());
+                Object rejectedValue = e.getRejectedValue();
+                if (rejectedValue != null) {
+                    jsonGenerator.writeStringField("rejectedValue", rejectedValue.toString());
+                }
+                jsonGenerator.writeEndObject();
+            } catch (IOException ioException) {
+                ioException.printStackTrace();
+            }
+        });
+
+        errors.getGlobalErrors().forEach(e -> {
+            try {
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeStringField("objectName", e.getObjectName());
+                jsonGenerator.writeStringField("code", e.getCode());
+                jsonGenerator.writeStringField("defaultMessage", e.getDefaultMessage());
+                jsonGenerator.writeEndObject();
+            } catch (IOException ioException) {
+                ioException.printStackTrace();
+            }
+        });
+        jsonGenerator.writeEndArray();
+    }
+
+}

--- a/src/main/java/com/example/springrestapi/events/Event.java
+++ b/src/main/java/com/example/springrestapi/events/Event.java
@@ -2,12 +2,15 @@ package com.example.springrestapi.events;
 
 import lombok.*;
 
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Builder @AllArgsConstructor @NoArgsConstructor
 @Getter @Setter @EqualsAndHashCode(of = "id")
+@Entity
 public class Event {
 
+    @Id @GeneratedValue
     private Integer id;
     private String name;
     private String description;
@@ -21,6 +24,7 @@ public class Event {
     private int limitOfEnrollment;
     private boolean offline;
     private boolean free;
+    @Enumerated(EnumType.STRING)
     private EventStatus eventStatus;
 
 }

--- a/src/main/java/com/example/springrestapi/events/Event.java
+++ b/src/main/java/com/example/springrestapi/events/Event.java
@@ -27,4 +27,17 @@ public class Event {
     @Enumerated(EnumType.STRING)
     private EventStatus eventStatus = EventStatus.DRAFT;
 
+    public void update() {
+        if (this.basePrice == 0 && this.maxPrice == 0) {
+            this.free = true;
+        } else {
+            this.free = false;
+        }
+
+        if (this.location == null || this.location.isBlank()) {
+            this.offline = false;
+        } else {
+            this.offline = true;
+        }
+    }
 }

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -1,0 +1,25 @@
+package com.example.springrestapi.events;
+
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.net.URI;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+@Controller
+@RequestMapping(value = "/api/events", produces = MediaTypes.HAL_JSON_VALUE)
+public class EventController {
+
+    @PostMapping
+    public ResponseEntity createEvent(@RequestBody Event event) {
+        URI createdUri = linkTo(EventController.class).slash("{id}").toUri();
+        event.setId(10);
+        return ResponseEntity.created(createdUri).body(event);
+    }
+
+}

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -36,6 +36,7 @@ public class EventController {
         }
 
         Event event = modelMapper.map(eventDto, Event.class);
+        event.update();
         Event newEvent = this.eventRepository.save(event);
         URI createdUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();
         return ResponseEntity.created(createdUri).body(event);

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -1,5 +1,6 @@
 package com.example.springrestapi.events;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,13 +13,16 @@ import java.net.URI;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @Controller
+@RequiredArgsConstructor
 @RequestMapping(value = "/api/events", produces = MediaTypes.HAL_JSON_VALUE)
 public class EventController {
 
+    private final EventRepository eventRepository;
+
     @PostMapping
     public ResponseEntity createEvent(@RequestBody Event event) {
-        URI createdUri = linkTo(EventController.class).slash("{id}").toUri();
-        event.setId(10);
+        Event newEvent = this.eventRepository.save(event);
+        URI createdUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();
         return ResponseEntity.created(createdUri).body(event);
     }
 

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -27,12 +27,12 @@ public class EventController {
     @PostMapping
     public ResponseEntity createEvent(@RequestBody @Valid EventDto eventDto, Errors errors) {
         if (errors.hasErrors()) { // 입력값이 비어있는 경우
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(errors);
         }
 
         eventValidator.validate(eventDto, errors);
         if (errors.hasErrors()) { // 입력값이 잘못된 경우
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(errors);
         }
 
         Event event = modelMapper.map(eventDto, Event.class);

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -1,6 +1,7 @@
 package com.example.springrestapi.events;
 
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -18,9 +19,11 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 public class EventController {
 
     private final EventRepository eventRepository;
+    private final ModelMapper modelMapper;
 
     @PostMapping
-    public ResponseEntity createEvent(@RequestBody Event event) {
+    public ResponseEntity createEvent(@RequestBody EventDto eventDto) {
+        Event event = modelMapper.map(eventDto, Event.class);
         Event newEvent = this.eventRepository.save(event);
         URI createdUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();
         return ResponseEntity.created(createdUri).body(event);

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -5,10 +5,12 @@ import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import javax.validation.Valid;
 import java.net.URI;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -20,9 +22,19 @@ public class EventController {
 
     private final EventRepository eventRepository;
     private final ModelMapper modelMapper;
+    private final EventValidator eventValidator;
 
     @PostMapping
-    public ResponseEntity createEvent(@RequestBody EventDto eventDto) {
+    public ResponseEntity createEvent(@RequestBody @Valid EventDto eventDto, Errors errors) {
+        if (errors.hasErrors()) { // 입력값이 비어있는 경우
+            return ResponseEntity.badRequest().build();
+        }
+
+        eventValidator.validate(eventDto, errors);
+        if (errors.hasErrors()) { // 입력값이 잘못된 경우
+            return ResponseEntity.badRequest().build();
+        }
+
         Event event = modelMapper.map(eventDto, Event.class);
         Event newEvent = this.eventRepository.save(event);
         URI createdUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();

--- a/src/main/java/com/example/springrestapi/events/EventDto.java
+++ b/src/main/java/com/example/springrestapi/events/EventDto.java
@@ -1,17 +1,16 @@
 package com.example.springrestapi.events;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Builder @AllArgsConstructor @NoArgsConstructor
-@Getter @Setter @EqualsAndHashCode(of = "id")
-@Entity
-public class Event {
+@Builder @NoArgsConstructor @AllArgsConstructor
+@Data
+public class EventDto { // 입력값 제한
 
-    @Id @GeneratedValue
-    private Integer id;
     private String name;
     private String description;
     private LocalDateTime beginEnrollmentDateTime;
@@ -22,9 +21,5 @@ public class Event {
     private int basePrice; // (optional)
     private int maxPrice; // (optional)
     private int limitOfEnrollment;
-    private boolean offline;
-    private boolean free;
-    @Enumerated(EnumType.STRING)
-    private EventStatus eventStatus = EventStatus.DRAFT;
 
 }

--- a/src/main/java/com/example/springrestapi/events/EventDto.java
+++ b/src/main/java/com/example/springrestapi/events/EventDto.java
@@ -5,21 +5,33 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Builder @NoArgsConstructor @AllArgsConstructor
 @Data
 public class EventDto { // 입력값 제한
 
+    @NotEmpty
     private String name;
+    @NotEmpty
     private String description;
+    @NotNull
     private LocalDateTime beginEnrollmentDateTime;
+    @NotNull
     private LocalDateTime closeEnrollmentDateTime;
+    @NotNull
     private LocalDateTime beginEventDateTime;
+    @NotNull
     private LocalDateTime endEventDateTime;
     private String location; // (optional) 이게 없으면 온라인 모임
+    @Min(0)
     private int basePrice; // (optional)
+    @Min(0)
     private int maxPrice; // (optional)
+    @Min(0)
     private int limitOfEnrollment;
 
 }

--- a/src/main/java/com/example/springrestapi/events/EventRepository.java
+++ b/src/main/java/com/example/springrestapi/events/EventRepository.java
@@ -1,0 +1,6 @@
+package com.example.springrestapi.events;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Integer> {
+}

--- a/src/main/java/com/example/springrestapi/events/EventValidator.java
+++ b/src/main/java/com/example/springrestapi/events/EventValidator.java
@@ -12,6 +12,7 @@ public class EventValidator {
         if (eventDto.getBasePrice() > eventDto.getMaxPrice() && eventDto.getMaxPrice() != 0) {
             errors.rejectValue("basePrice", "wrongValue", "BasePrice is wrong.");
             errors.rejectValue("maxPrice", "wrongValue", "MaxPrice is wrong.");
+            errors.reject("wrongPrice", "Values of Prices are wrong.");
         }
 
         LocalDateTime endEventDateTime = eventDto.getEndEventDateTime();

--- a/src/main/java/com/example/springrestapi/events/EventValidator.java
+++ b/src/main/java/com/example/springrestapi/events/EventValidator.java
@@ -1,0 +1,23 @@
+package com.example.springrestapi.events;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.time.LocalDateTime;
+
+@Component
+public class EventValidator {
+
+    public void validate(EventDto eventDto, Errors errors) {
+        if (eventDto.getBasePrice() > eventDto.getMaxPrice() && eventDto.getMaxPrice() != 0) {
+            errors.rejectValue("basePrice", "wrongValue", "BasePrice is wrong.");
+            errors.rejectValue("maxPrice", "wrongValue", "MaxPrice is wrong.");
+        }
+
+        LocalDateTime endEventDateTime = eventDto.getEndEventDateTime();
+        if (endEventDateTime.isBefore(eventDto.getBeginEventDateTime()) || endEventDateTime.isBefore(eventDto.getCloseEnrollmentDateTime()) || endEventDateTime.isBefore(eventDto.getBeginEnrollmentDateTime())) {
+            errors.rejectValue("endEventDateTime", "wrongValue", "endEventDateTime is wrong.");
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+# \uBC1B\uC744 \uC218 \uC5C6\uB294 properties\uAC00 \uC785\uB825 \uB420 \uC2DC Bad Request \uBC1C\uC0DD
+spring.jackson.deserialization.fail-on-unknown-properties=true

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -2,13 +2,11 @@ package com.example.springrestapi.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -31,6 +29,7 @@ public class EventControllerTests {
     ObjectMapper objectMapper;
 
     @Test
+    @DisplayName("정상적으로 이벤트를 생성하는 테스트")
     public void createEvent() throws Exception {
         EventDto event = EventDto.builder()
                 .name("Spring")
@@ -61,6 +60,7 @@ public class EventControllerTests {
     }
 
     @Test
+    @DisplayName("입력 받을 수 없는 값을 사용한 경우에 에러를 발생하는 테스트")
     public void createEvent_Bad_Request() throws Exception {
         Event event = Event.builder()
                 .id(100)
@@ -80,10 +80,43 @@ public class EventControllerTests {
                 .build();
 
         mockMvc.perform(post("/api/events/")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(event)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaTypes.HAL_JSON)
+                    .content(objectMapper.writeValueAsString(event)))
                 .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("입력값이 비어있는 경우에 에러를 발생하는 테스트")
+    public void createEvent_Bad_Request_Empty_Input() throws Exception {
+        EventDto eventDto = EventDto.builder().build();
+
+        mockMvc.perform(post("/api/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(eventDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("입력값이 잘못된 경우에 에러를 발생하는 테스트")
+    public void createEvent_Bad_Request_Wrong_Input() throws Exception {
+        EventDto eventDto = EventDto.builder()
+                .name("Spring")
+                .description("REST API Development with Spring")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 10, 18, 13, 27))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 10, 17, 13, 27))
+                .beginEventDateTime(LocalDateTime.of(2020, 10, 20, 13, 27))
+                .endEventDateTime(LocalDateTime.of(2020, 10, 19, 13, 27))
+                .basePrice(10000)
+                .maxPrice(200)
+                .limitOfEnrollment(100)
+                .location("D2 스타트업 팩토리")
+                .build();
+
+        mockMvc.perform(post("/api/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(eventDto)))
                 .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -117,7 +117,11 @@ public class EventControllerTests {
         mockMvc.perform(post("/api/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(eventDto)))
-                .andExpect(status().isBadRequest());
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$[0].objectName").exists())
+                .andExpect(jsonPath("$[0].defaultMessage").exists())
+                .andExpect(jsonPath("$[0].code").exists());
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -1,10 +1,13 @@
 package com.example.springrestapi.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
@@ -17,7 +20,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest
+@SpringBootTest
+@AutoConfigureMockMvc
 public class EventControllerTests {
 
     @Autowired
@@ -26,12 +30,10 @@ public class EventControllerTests {
     @Autowired
     ObjectMapper objectMapper;
 
-    @MockBean
-    EventRepository eventRepository;
-
     @Test
     public void createEvent() throws Exception {
         Event event = Event.builder()
+                .id(100)
                 .name("Spring")
                 .description("REST API Development with Spring")
                 .beginEnrollmentDateTime(LocalDateTime.of(2020, 10, 18, 13, 27))
@@ -42,10 +44,10 @@ public class EventControllerTests {
                 .maxPrice(200)
                 .limitOfEnrollment(100)
                 .location("D2 스타트업 팩토리")
+                .free(true) // 무시 해야 하는 값
+                .offline(false) // 무시 해야 하는 값
+                .eventStatus(EventStatus.PUBLISHED) // 무시 해야 하는 값
                 .build();
-
-        event.setId(10);
-        Mockito.when(eventRepository.save(event)).thenReturn(event);
 
         mockMvc.perform(post("/api/events/")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -55,8 +57,11 @@ public class EventControllerTests {
                 .andExpect(status().isCreated()) // 201
                 .andExpect(jsonPath("id").exists())
                 .andExpect(header().exists(HttpHeaders.LOCATION))
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE));
-
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE))
+                .andExpect(jsonPath("id").value(Matchers.not(100)))
+                .andExpect(jsonPath("free").value(Matchers.not(true)))
+                .andExpect(jsonPath("free").value(Matchers.not(true)))
+                .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()));
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -32,6 +32,36 @@ public class EventControllerTests {
 
     @Test
     public void createEvent() throws Exception {
+        EventDto event = EventDto.builder()
+                .name("Spring")
+                .description("REST API Development with Spring")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 10, 18, 13, 27))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 10, 19, 13, 27))
+                .beginEventDateTime(LocalDateTime.of(2020, 10, 20, 13, 27))
+                .endEventDateTime(LocalDateTime.of(2020, 10, 21, 13, 27))
+                .basePrice(100)
+                .maxPrice(200)
+                .limitOfEnrollment(100)
+                .location("D2 스타트업 팩토리")
+                .build();
+
+        mockMvc.perform(post("/api/events/")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaTypes.HAL_JSON)
+                    .content(objectMapper.writeValueAsString(event)))
+                .andDo(print())
+                .andExpect(status().isCreated()) // 201
+                .andExpect(jsonPath("id").exists())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE))
+                .andExpect(jsonPath("id").value(Matchers.not(100)))
+                .andExpect(jsonPath("free").value(Matchers.not(true)))
+                .andExpect(jsonPath("free").value(Matchers.not(true)))
+                .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()));
+    }
+
+    @Test
+    public void createEvent_Bad_Request() throws Exception {
         Event event = Event.builder()
                 .id(100)
                 .name("Spring")
@@ -50,18 +80,11 @@ public class EventControllerTests {
                 .build();
 
         mockMvc.perform(post("/api/events/")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaTypes.HAL_JSON)
-                    .content(objectMapper.writeValueAsString(event)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaTypes.HAL_JSON)
+                .content(objectMapper.writeValueAsString(event)))
                 .andDo(print())
-                .andExpect(status().isCreated()) // 201
-                .andExpect(jsonPath("id").exists())
-                .andExpect(header().exists(HttpHeaders.LOCATION))
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE))
-                .andExpect(jsonPath("id").value(Matchers.not(100)))
-                .andExpect(jsonPath("free").value(Matchers.not(true)))
-                .andExpect(jsonPath("free").value(Matchers.not(true)))
-                .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()));
+                .andExpect(status().isBadRequest());
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -1,29 +1,51 @@
 package com.example.springrestapi.events;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
 @WebMvcTest
 public class EventControllerTests {
 
     @Autowired
     MockMvc mockMvc;
 
+    @Autowired
+    ObjectMapper objectMapper;
+
     @Test
     public void createEvent() throws Exception {
+        Event event = Event.builder()
+                .name("Spring")
+                .description("REST API Development with Spring")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 10, 18, 13, 27))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 10, 19, 13, 27))
+                .beginEventDateTime(LocalDateTime.of(2020, 10, 20, 13, 27))
+                .endEventDateTime(LocalDateTime.of(2020, 10, 21, 13, 27))
+                .basePrice(100)
+                .maxPrice(200)
+                .limitOfEnrollment(100)
+                .location("D2 스타트업 팩토리")
+                .build();
+
         mockMvc.perform(post("/api/events/")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isCreated()); // 201
+                    .accept(MediaTypes.HAL_JSON)
+                    .content(objectMapper.writeValueAsString(event)))
+                .andDo(print())
+                .andExpect(status().isCreated()) // 201
+                .andExpect(jsonPath("id").exists());
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -2,9 +2,12 @@ package com.example.springrestapi.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -12,8 +15,7 @@ import java.time.LocalDateTime;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest
 public class EventControllerTests {
@@ -23,6 +25,9 @@ public class EventControllerTests {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @MockBean
+    EventRepository eventRepository;
 
     @Test
     public void createEvent() throws Exception {
@@ -39,13 +44,19 @@ public class EventControllerTests {
                 .location("D2 스타트업 팩토리")
                 .build();
 
+        event.setId(10);
+        Mockito.when(eventRepository.save(event)).thenReturn(event);
+
         mockMvc.perform(post("/api/events/")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaTypes.HAL_JSON)
                     .content(objectMapper.writeValueAsString(event)))
                 .andDo(print())
                 .andExpect(status().isCreated()) // 201
-                .andExpect(jsonPath("id").exists());
+                .andExpect(jsonPath("id").exists())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE));
+
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -53,9 +53,8 @@ public class EventControllerTests {
                 .andExpect(jsonPath("id").exists())
                 .andExpect(header().exists(HttpHeaders.LOCATION))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_VALUE))
-                .andExpect(jsonPath("id").value(Matchers.not(100)))
-                .andExpect(jsonPath("free").value(Matchers.not(true)))
-                .andExpect(jsonPath("free").value(Matchers.not(true)))
+                .andExpect(jsonPath("free").value(false))
+                .andExpect(jsonPath("offline").value(true))
                 .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()));
     }
 

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -1,0 +1,29 @@
+package com.example.springrestapi.events;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@WebMvcTest
+public class EventControllerTests {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    public void createEvent() throws Exception {
+        mockMvc.perform(post("/api/events/")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isCreated()); // 201
+    }
+
+}

--- a/src/test/java/com/example/springrestapi/events/EventTest.java
+++ b/src/test/java/com/example/springrestapi/events/EventTest.java
@@ -34,4 +34,67 @@ class EventTest {
         assertThat(event.getDescription()).isEqualTo(description);
     }
 
+    @Test
+    public void testFree() {
+        // given
+        Event event = Event.builder()
+                .basePrice(0)
+                .maxPrice(0)
+                .build();
+
+        // when
+        event.update();
+
+        // then
+        assertThat(event.isFree()).isTrue();
+
+        // given
+        event = Event.builder()
+                .basePrice(100)
+                .maxPrice(0)
+                .build();
+
+        // when
+        event.update();
+
+        // then
+        assertThat(event.isFree()).isFalse();
+
+        // given
+        event = Event.builder()
+                .basePrice(0)
+                .maxPrice(100)
+                .build();
+
+        // when
+        event.update();
+
+        // then
+        assertThat(event.isFree()).isFalse();
+    }
+
+    @Test
+    public void testOffline() {
+        // given
+        Event event = Event.builder()
+                .location("D2 스타트업 팩토리")
+                .build();
+
+        // when
+        event.update();
+
+        // then
+        assertThat(event.isOffline()).isTrue();
+
+        // given
+        event = Event.builder()
+                .build();
+
+        // when
+        event.update();
+
+        // then
+        assertThat(event.isOffline()).isFalse();
+    }
+
 }

--- a/src/test/java/com/example/springrestapi/events/EventTest.java
+++ b/src/test/java/com/example/springrestapi/events/EventTest.java
@@ -1,11 +1,17 @@
 package com.example.springrestapi.events;
 
+import junitparams.JUnitParamsRunner;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.runner.RunWith;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@RunWith(JUnitParamsRunner.class)
 class EventTest {
 
     @Test
@@ -34,67 +40,47 @@ class EventTest {
         assertThat(event.getDescription()).isEqualTo(description);
     }
 
-    @Test
-    public void testFree() {
+    @ParameterizedTest
+    @MethodSource("parametersForTestFree")
+    public void testFree(int basePrice, int maxPrice, boolean isFree) {
         // given
         Event event = Event.builder()
-                .basePrice(0)
-                .maxPrice(0)
+                .basePrice(basePrice)
+                .maxPrice(maxPrice)
                 .build();
-
         // when
         event.update();
-
         // then
-        assertThat(event.isFree()).isTrue();
-
-        // given
-        event = Event.builder()
-                .basePrice(100)
-                .maxPrice(0)
-                .build();
-
-        // when
-        event.update();
-
-        // then
-        assertThat(event.isFree()).isFalse();
-
-        // given
-        event = Event.builder()
-                .basePrice(0)
-                .maxPrice(100)
-                .build();
-
-        // when
-        event.update();
-
-        // then
-        assertThat(event.isFree()).isFalse();
+        assertThat(event.isFree()).isEqualTo(isFree);
     }
 
-    @Test
-    public void testOffline() {
+    private static Stream<Arguments> parametersForTestFree() {
+        return Stream.of(
+                Arguments.of(0, 0, true),
+                Arguments.of(100, 0, false),
+                Arguments.of(0, 100, false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestOffline")
+    public void testOffline(String location, boolean isOffline) {
         // given
         Event event = Event.builder()
-                .location("D2 스타트업 팩토리")
+                .location(location)
                 .build();
-
         // when
         event.update();
-
         // then
-        assertThat(event.isOffline()).isTrue();
+        assertThat(event.isOffline()).isEqualTo(isOffline);
+    }
 
-        // given
-        event = Event.builder()
-                .build();
-
-        // when
-        event.update();
-
-        // then
-        assertThat(event.isOffline()).isFalse();
+    private static Stream<Arguments> parametersForTestOffline() {
+        return Stream.of(
+                Arguments.of("D2 스타트업 팩토리", true),
+                Arguments.of(null, false),
+                Arguments.of("", false)
+        );
     }
 
 }


### PR DESCRIPTION
## Event 생성 API 구현: 테스트 클래스

**스프링 부트 슬라이스 테스트**
- @WebMvcTest
    - MockMvc 빈을 자동 설정 해준다. 따라서 그냥 가져와서 쓰면 됨.
    - 웹 관련 빈만 등록해 준다. (슬라이스)

**MockMvc**
- 스프링 MVC 테스트 핵심 클래스
- 웹 서버를 띄우지 않고도 스프링 MVC (DispatcherServlet)가 요청을 처리하는 과정을 확인할 수 있기 때문에 컨트롤러 테스트용으로 자주 쓰임.

테스트 할 것
- 입력값들을 전달하면 JSON 응답으로 201이 나오는지 확인.
    - Location 헤더에 생성된 이벤트를 조회할 수 있는 URI 담겨 있는지 확인
    - id는 DB에 들어갈 때 자동생성된 값으로 나오는지 확인
- 입력값으로 누가 id나 eventStatus, offline, free 이런 데이터까지 같이 주면?
    - Bad_Request로 응답 vs **받기로 한 값 이외는 무시**
- 입력 데이터가 이상한 경우 Bad_Request로 응답
    - 입력값이 이상한 경우 에러
    - 비즈니스 로직으로 검사할 수 있는 에러
    - 에러 응답 메시지에 에러에 대한 정보가 있어야 한다.
- 비즈니스 로직 적용 됐는지 응답 메시지 확인
    - offline과 free 값 확인
- 응답에 HATEOA와 profile 관련 링크가 있는지 확인.
    - self (view)
    - update (만든 사람은 수정할 수 있으니까)
    - events (목록으로 가는 링크)
- API 문서 만들기
    - 요청 문서화
    - 응답 문서화
    - 링크 문서화
    - profile 링크 추가

## Event 생성 API 구현: 201 응답 받기

@RestController
- @ResponseBody를 모든 메소드에 적용한 것과 동일하다.

ResponseEntity를 사용하는 이유
- 응답 코드, 헤더, 본문 모두 다루기 편한 API

Location URI 만들기
- HATEOS가 제공하는 linkTo(), methodOn() 사용

객체를 JSON으로 변환
- ObjectMapper 사용

테스트 할 것
- 입력값들을 전달하면 JSON 응답으로 201이 나오는지 확인
    - **Location 헤더에 생성된 이벤트를 조회할 수 있는 URI 담겨 있는지 확인**
    - id는 DB에 들어갈 때 자동생성된 값으로 나오는지 확인

## Event 생성 API 구현: EventRepository 구현

스프링 데이터 JPA
- JpaRepository 상속 받아 만들기

Enum을 JPA 맵핑시 주의할 것
- @Enumerated(EnumType.STRING)

@MockBean
- Mockito를 사용해서 mock 객체를 만들고 빈으로 등록해 줌.
- (주의) 기존 빈을 테스트용 빈이 대체 한다.

테스트 할 것
- 입력값들을 전달하면 JSON 응답으로 201이 나오는지 확인.
    - Location 헤더에 생성된 이벤트를 조회할 수 있는 URI 담겨 있는지 확인
    - **id는 DB에 들어갈 때 자동생성된 값으로 나오는지 확인**

## Event 생성 API 구현: 입력값 제한하기

입력값 제한
- id 또는 입력 받은 데이터로 계산해야 하는 값들은 입력을 받지 않아야 한다.
- EventDto 적용

DTO -> 도메인 객체로 값 복사
- ModelMapper
```java
<dependency>
            <groupId>org.modelmapper</groupId>
            <artifactId>modelmapper</artifactId>
            <version>2.3.1</version>
</dependency>
```

통합 테스트로 전환
- @WebMvcTest 빼고 다음 애노테이션 추가
    - @SpringBootTest
    - @AutoConfigureMockMvc
- Repository @MockBean 코드 제거

테스트 할 것
- 입력값으로 누가 id나 eventStatus, offline, free 이런 데이터까지 같이 주면?
    - Bad_Request로 응답 vs **받기로 한 값 이외는 무시**

## Event 생성 API 구현: 입력값 이외에 에러 발생

ObjectMapper 커스터마이징
- spring.jackson.deserialization.fail-on-unknown-properties=true

테스트 할 것
- 입력값으로 누가 id나 eventStatus, offline, free 이런 데이터까지 같이 주면?
    - **Bad_Request로 응답** vs 받기로 한 값 이외는 무시

## Event 생성 API 구현: Bad Request 처리하기

@Valid와 BindingResult (또는 Errors)
- BindingResult는 항상 @Valid 바로 다음 인자로 사용해야 함. (스프링 MVC)
- @NotNull, @NotEmpty, @Min, @Max, ... 사용해서 입력값 바인딩할 때 에러 확인할 수 있음

도메인 Validator 만들기
- Validator 인터페이스 없이 만들어도 상관없음

테스트 설명 용 애노테이션 만들기
- @Target, @Retention

테스트 할 것
- 입력 데이터가 이상한 경우 Bad_Request로 응답
    - **입력값이 이상한 경우 에러**
    - **비즈니스 로직으로 검사할 수 있는 에러**
    - 에러 응답 메시지에 에러에 대한 정보가 있어야 한다.

## Event 생성 API 구현: Bad Request 응답 본문 만들기

커스텀 JSON Serializer 만들기
- extends JsonSerializer<T> (Jackson JSON 제공)
- @JsonComponent (스프링 부트 제공)

BindingError
- FieldError 와 GlobalError (ObjectError)가 있음
- objectName
- defaultMessage
- code
- field
- rejectedValue

테스트 할 것
- 입력 데이터가 이상한 경우 Bad_Request로 응답
    - 입력값이 이상한 경우 에러
    - 비즈니스 로직으로 검사할 수 있는 에러
    - **에러 응답 메시지에 에러에 대한 정보가 있어야 한다.**

## Event 생성 API 구현: 비즈니스 로직 적용

테스트 할 것
- 비즈니스 로직 적용 됐는지 응답 메시지 확인
    - offline과 free 값 확인

## Event 생성 API 구현: 매개변수를 이용한 테스트

테스트 코드 리팩토링
- 테스트에서 중복 코드 제거
- 매개변수만 바꿀 수 있으면 좋겠는데?
- JUnitParams

JUnitParams
- https://github.com/Pragmatists/JUnitParams
```java
<!-- https://mvnrepository.com/artifact/pl.pragmatists/JUnitParams -->
<dependency>
    <groupId>pl.pragmatists</groupId>
    <artifactId>JUnitParams</artifactId>
    <version>1.1.1</version>
    <scope>test</scope>
</dependency>
```