### PR TITLE
HATEOAS와 Self-Describtive Message 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
+<!--            <scope>test</scope>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -83,9 +83,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.8</version>
+                <version>1.5.3</version>
                 <executions>
                     <execution>
                         <id>generate-docs</id>
@@ -103,13 +107,34 @@
                     <dependency>
                         <groupId>org.springframework.restdocs</groupId>
                         <artifactId>spring-restdocs-asciidoctor</artifactId>
-                        <version>${spring-restdocs.version}</version>
+                        <version>2.0.2.RELEASE</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/static/docs
+                            </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/generated-docs
+                                    </directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/scripts.md
+++ b/scripts.md
@@ -1,0 +1,93 @@
+# Scripts
+
+Here, I memo scripts that I have used during development.
+
+## Postgres
+
+### Run Postgres Container
+
+```
+docker run --name spring-restapi -p 5432:5432 -e POSTGRES_PASSWORD=pass -d postgres
+
+```
+
+This cmdlet will create Postgres instance so that you can connect to a database with:
+* database: postgres
+* username: postgres
+* password: pass
+* post: 5432
+
+### Getting into the Postgres container
+
+```
+docker exec -i -t spring-restapi bash
+```
+
+Then you will see the containers bash as a root user.
+
+## 유저 변경
+
+```
+su - postgres
+```
+
+### Connect to a database
+
+```
+psql -d postgres -U postgres
+```
+
+## 비밀번호로 접속하기
+
+```
+psql -d postgres -U postgres -W
+```
+
+### Query Databases
+
+```
+\l
+```
+
+### Query Tables
+
+```
+\dt
+```
+
+### Quit
+
+```
+\q
+```
+
+## application.properties
+
+### Datasource
+
+```
+spring.datasource.username=postgres
+spring.datasource.password=pass
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+```
+
+### Hibernate
+
+```
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.format_sql=true
+
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+```
+
+### Test Database
+
+```
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+```

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,0 +1,128 @@
+= REST API Guide
+김준한;
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:operation-curl-request-title: Example request
+:operation-http-response-title: Example response
+
+[[overview]]
+= 개요
+
+[[overview-http-verbs]]
+== HTTP 동사
+
+본 REST API에서 사용하는 HTTP 동사(verbs)는 가능한한 표준 HTTP와 REST 규약을 따릅니다.
+
+|===
+| 동사 | 용례
+
+| `GET`
+| 리소스를 가져올 때 사용
+
+| `POST`
+| 새 리소스를 만들 때 사용
+
+| `PUT`
+| 기존 리소스를 수정할 때 사용
+
+| `PATCH`
+| 기존 리소스의 일부를 수정할 때 사용
+
+| `DELETE`
+| 기존 리소스를 삭제할 떄 사용
+|===
+
+[[overview-http-status-codes]]
+== HTTP 상태 코드
+
+본 REST API에서 사용하는 HTTP 상태 코드는 가능한한 표준 HTTP와 REST 규약을 따릅니다.
+
+|===
+| 상태 코드 | 용례
+
+| `200 OK`
+| 요청을 성공적으로 처리함
+
+| `201 Created`
+| 새 리소스를 성공적으로 생성함. 응답의 `Location` 헤더에 해당 리소스의 URI가 담겨있다.
+
+| `204 No Content`
+| 기존 리소스를 성공적으로 수정함.
+
+| `400 Bad Request`
+| 잘못된 요청을 보낸 경우. 응답 본문에 더 오류에 대한 정보가 담겨있다.
+
+| `404 Not Found`
+| 요청한 리소스가 없음.
+|===
+
+[[overview-errors]]
+== 오류
+
+에러 응답이 발생했을 때 (상태 코드 >= 400), 본문에 해당 문제를 기술한 JSON 객체가 담겨있다. 에러 객체는 다음의 구조를 따른다.
+
+include::{snippets}/errors/response-fields.adoc[]
+
+예를 들어, 잘못된 요청으로 이벤트를 만들려고 했을 때 다음과 같은 `400 Bad Request` 응답을 받는다.
+
+include::{snippets}/errors/http-response.adoc[]
+
+[[overview-hypermedia]]
+== 하이퍼미디어
+
+본 REST API는 하이퍼미디어와 사용하며 응답에 담겨있는 리소스는 다른 리소스에 대한 링크를 가지고 있다.
+응답은 http://stateless.co/hal_specification.html[Hypertext Application from resource to resource. Language (HAL)] 형식을 따른다.
+링크는 `_links`라는 키로 제공한다. 본 API의 사용자(클라이언트)는 URI를 직접 생성하지 않아야 하며, 리소스에서 제공하는 링크를 사용해야 한다.
+
+[[resources]]
+= 리소스
+
+[[resources-index]]
+== 인덱스
+
+인덱스는 서비스 진입점을 제공한다.
+
+
+[[resources-index-access]]
+=== 인덱스 조회
+
+`GET` 요청을 사용하여 인덱스에 접근할 수 있다.
+
+operation::index[snippets='response-body,http-response,links']
+
+[[resources-events]]
+== 이벤트
+
+이벤트 리소스는 이벤트를 만들거나 조회할 때 사용한다.
+
+[[resources-events-list]]
+=== 이벤트 목록 조회
+
+`GET` 요청을 사용하여 서비스의 모든 이벤트를 조회할 수 있다.
+
+operation::get-events[snippets='response-fields,curl-request,http-response,links']
+
+[[resources-events-create]]
+=== 이벤트 생성
+
+`POST` 요청을 사용해서 새 이벤트를 만들 수 있다.
+
+operation::create-event[snippets='request-fields,curl-request,http-request,request-headers,http-response,response-headers,response-fields,links']
+
+[[resources-events-get]]
+=== 이벤트 조회
+
+`Get` 요청을 사용해서 기존 이벤트 하나를 조회할 수 있다.
+
+operation::get-event[snippets='request-fields,curl-request,http-response,links']
+
+[[resources-events-update]]
+=== 이벤트 수정
+
+`PUT` 요청을 사용해서 기존 이벤트를 수정할 수 있다.
+
+operation::update-events[snippets='request-fields,curl-request,http-response,links']

--- a/src/main/java/com/example/springrestapi/common/ErrorSerializer.java
+++ b/src/main/java/com/example/springrestapi/common/ErrorSerializer.java
@@ -13,6 +13,7 @@ public class ErrorSerializer extends JsonSerializer<Errors> {
 
     @Override
     public void serialize(Errors errors, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeFieldName("errors");
         jsonGenerator.writeStartArray();
         errors.getFieldErrors().forEach(e -> {
             try {

--- a/src/main/java/com/example/springrestapi/common/ErrorsResource.java
+++ b/src/main/java/com/example/springrestapi/common/ErrorsResource.java
@@ -1,0 +1,17 @@
+package com.example.springrestapi.common;
+
+import com.example.springrestapi.index.IndexController;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.validation.Errors;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+public class ErrorsResource extends EntityModel<Errors> {
+
+    public ErrorsResource(Errors content, Link... links) {
+        super(content, links);
+        add(linkTo(methodOn(IndexController.class).index()).withRel("index"));
+    }
+}

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -2,6 +2,7 @@ package com.example.springrestapi.events;
 
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.ResponseEntity;
@@ -46,6 +47,7 @@ public class EventController {
         EventResource eventResource = new EventResource(newEvent);
         eventResource.add(linkTo(EventController.class).withRel("query-events"));
         eventResource.add(selfLinkBuilder.withRel("update-events"));
+        eventResource.add(new Link("/docs/index.html#resources-events-create").withRel("profile"));
 
         // EventResource 객체를 생성하지 않고 처리하는 법
 //        EntityModel eventResource = EntityModel.of(newEvent);

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -1,5 +1,6 @@
 package com.example.springrestapi.events;
 
+import com.example.springrestapi.common.ErrorsResource;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.Link;
@@ -29,12 +30,12 @@ public class EventController {
     @PostMapping
     public ResponseEntity createEvent(@RequestBody @Valid EventDto eventDto, Errors errors) {
         if (errors.hasErrors()) { // 입력값이 비어있는 경우
-            return ResponseEntity.badRequest().body(errors);
+            return badRequest(errors);
         }
 
         eventValidator.validate(eventDto, errors);
         if (errors.hasErrors()) { // 입력값이 잘못된 경우
-            return ResponseEntity.badRequest().body(errors);
+            return badRequest(errors);
         }
 
         Event event = modelMapper.map(eventDto, Event.class);
@@ -56,6 +57,10 @@ public class EventController {
 //        eventResource.add(selfLinkBuilder.withRel("update-events"));
 
         return ResponseEntity.created(createdUri).body(eventResource);
+    }
+
+    private ResponseEntity badRequest(Errors errors) {
+        return ResponseEntity.badRequest().body(new ErrorsResource(errors));
     }
 
 }

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -47,7 +47,7 @@ public class EventController {
         eventResource.add(linkTo(EventController.class).withRel("query-events"));
         eventResource.add(selfLinkBuilder.withRel("update-events"));
 
-//        // EventResource 객체를 생성하지 않고 처리하는 법
+        // EventResource 객체를 생성하지 않고 처리하는 법
 //        EntityModel eventResource = EntityModel.of(newEvent);
 //        eventResource.add(selfLinkBuilder.withSelfRel());
 //        eventResource.add(linkTo(EventController.class).withRel("query-events"));

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -3,6 +3,7 @@ package com.example.springrestapi.events;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.Errors;
@@ -38,8 +39,21 @@ public class EventController {
         Event event = modelMapper.map(eventDto, Event.class);
         event.update();
         Event newEvent = this.eventRepository.save(event);
-        URI createdUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();
-        return ResponseEntity.created(createdUri).body(event);
+
+        WebMvcLinkBuilder selfLinkBuilder = linkTo(EventController.class).slash(newEvent.getId());
+        URI createdUri = selfLinkBuilder.toUri();
+
+        EventResource eventResource = new EventResource(newEvent);
+        eventResource.add(linkTo(EventController.class).withRel("query-events"));
+        eventResource.add(selfLinkBuilder.withRel("update-events"));
+
+//        // EventResource 객체를 생성하지 않고 처리하는 법
+//        EntityModel eventResource = EntityModel.of(newEvent);
+//        eventResource.add(selfLinkBuilder.withSelfRel());
+//        eventResource.add(linkTo(EventController.class).withRel("query-events"));
+//        eventResource.add(selfLinkBuilder.withRel("update-events"));
+
+        return ResponseEntity.created(createdUri).body(eventResource);
     }
 
 }

--- a/src/main/java/com/example/springrestapi/events/EventResource.java
+++ b/src/main/java/com/example/springrestapi/events/EventResource.java
@@ -1,0 +1,30 @@
+package com.example.springrestapi.events;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+//public class EventResource extends RepresentationModel {
+//
+//    @JsonUnwrapped
+//    private Event event;
+//
+//    public EventResource(Event event) {
+//        this.event = event;
+//    }
+//
+//    public Event getEvent() {
+//        return event;
+//    }
+//
+//}
+
+public class EventResource extends EntityModel<Event> {
+
+    public EventResource(Event event, Link... links) {
+        super(event, links);
+        add(linkTo(EventController.class).slash(event.getId()).withSelfRel()); // self 링크
+    }
+
+}

--- a/src/main/java/com/example/springrestapi/index/IndexController.java
+++ b/src/main/java/com/example/springrestapi/index/IndexController.java
@@ -1,0 +1,20 @@
+package com.example.springrestapi.index;
+
+import com.example.springrestapi.events.EventController;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+@RestController
+public class IndexController {
+
+    @GetMapping("/api")
+    public RepresentationModel index() {
+        var index = new RepresentationModel();
+        index.add(linkTo(EventController.class).withRel("events"));
+        return index;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 # \uBC1B\uC744 \uC218 \uC5C6\uB294 properties\uAC00 \uC785\uB825 \uB420 \uC2DC Bad Request \uBC1C\uC0DD
 spring.jackson.deserialization.fail-on-unknown-properties=true
+
+# \uD55C\uAE00 \uAE68\uC9D0 \uBC29\uC9C0
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,16 @@ spring.jackson.deserialization.fail-on-unknown-properties=true
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true
 server.servlet.encoding.force=true
+
+# \uB370\uC774\uD130\uC18C\uC2A4(docker postgresql DB) \uC5F0\uACB0
+spring.datasource.username=postgres
+spring.datasource.password=pass
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# \uD558\uC774\uBC84\uB124\uC774\uD2B8 \uC124\uC815
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/test/java/com/example/springrestapi/common/RestDocsConfiguration.java
+++ b/src/test/java/com/example/springrestapi/common/RestDocsConfiguration.java
@@ -1,0 +1,25 @@
+package com.example.springrestapi.common;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentationConfigurer;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer() {
+        return new RestDocsMockMvcConfigurationCustomizer() {
+            @Override
+            public void customize(MockMvcRestDocumentationConfigurer configurer) {
+                configurer.operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint());
+            }
+        };
+    }
+
+}

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -20,7 +20,11 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -79,7 +83,52 @@ public class EventControllerTests {
                 .andExpect(jsonPath("_links.self").exists())
                 .andExpect(jsonPath("_links.query-events").exists())
                 .andExpect(jsonPath("_links.update-events").exists())
-                .andDo(document("create-event"));
+                .andDo(document("create-event",
+                        links(
+                                linkWithRel("self").description("link to self"),
+                                linkWithRel("query-events").description("link to query events"),
+                                linkWithRel("update-events").description("link to update an existing event")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.ACCEPT).description("accept header"),
+                                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").description("Name of new event"),
+                                fieldWithPath("description").description("description of new event"),
+                                fieldWithPath("beginEnrollmentDateTime").description("date time of begin of new event"),
+                                fieldWithPath("closeEnrollmentDateTime").description("date time of close of new event"),
+                                fieldWithPath("beginEventDateTime").description("date time of begin of new event"),
+                                fieldWithPath("endEventDateTime").description("date time of close of new event"),
+                                fieldWithPath("location").description("location of new event"),
+                                fieldWithPath("basePrice").description("base price of new event"),
+                                fieldWithPath("maxPrice").description("max price of new event"),
+                                fieldWithPath("limitOfEnrollment").description("limit of enrollment")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("location header"),
+                                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("id of new event"),
+                                fieldWithPath("name").description("Name of new event"),
+                                fieldWithPath("description").description("description of new event"),
+                                fieldWithPath("beginEnrollmentDateTime").description("date time of begin of new event"),
+                                fieldWithPath("closeEnrollmentDateTime").description("date time of close of new event"),
+                                fieldWithPath("beginEventDateTime").description("date time of begin of new event"),
+                                fieldWithPath("endEventDateTime").description("date time of close of new event"),
+                                fieldWithPath("location").description("location of new event"),
+                                fieldWithPath("basePrice").description("base price of new event"),
+                                fieldWithPath("maxPrice").description("max price of new event"),
+                                fieldWithPath("limitOfEnrollment").description("limit of enrollment"),
+                                fieldWithPath("free").description("it tells is this event is free or not"),
+                                fieldWithPath("offline").description("it tells if this event is offline meeting or not"),
+                                fieldWithPath("eventStatus").description("event status"),
+                                fieldWithPath("_links.self.href").description("link to self"),
+                                fieldWithPath("_links.query-events.href").description("link to query event list"),
+                                fieldWithPath("_links.update-events.href").description("link to update existing event")
+                        )
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -83,11 +83,13 @@ public class EventControllerTests {
                 .andExpect(jsonPath("_links.self").exists())
                 .andExpect(jsonPath("_links.query-events").exists())
                 .andExpect(jsonPath("_links.update-events").exists())
+                .andExpect(jsonPath("_links.profile").exists())
                 .andDo(document("create-event",
                         links(
                                 linkWithRel("self").description("link to self"),
                                 linkWithRel("query-events").description("link to query events"),
-                                linkWithRel("update-events").description("link to update an existing event")
+                                linkWithRel("update-events").description("link to update an existing event"),
+                                linkWithRel("profile").description("link to profile")
                         ),
                         requestHeaders(
                                 headerWithName(HttpHeaders.ACCEPT).description("accept header"),
@@ -126,7 +128,8 @@ public class EventControllerTests {
                                 fieldWithPath("eventStatus").description("event status"),
                                 fieldWithPath("_links.self.href").description("link to self"),
                                 fieldWithPath("_links.query-events.href").description("link to query event list"),
-                                fieldWithPath("_links.update-events.href").description("link to update existing event")
+                                fieldWithPath("_links.update-events.href").description("link to update existing event"),
+                                fieldWithPath("_links.profile.href").description("link to profile")
                         )
                 ));
     }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @Import(RestDocsConfiguration.class)
+@ActiveProfiles("test")
 public class EventControllerTests {
 
     @Autowired

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -1,12 +1,15 @@
 package com.example.springrestapi.events;
 
+import com.example.springrestapi.common.RestDocsConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -17,12 +20,15 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
 public class EventControllerTests {
 
     @Autowired
@@ -72,7 +78,8 @@ public class EventControllerTests {
                 .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
                 .andExpect(jsonPath("_links.self").exists())
                 .andExpect(jsonPath("_links.query-events").exists())
-                .andExpect(jsonPath("_links.update-events").exists());
+                .andExpect(jsonPath("_links.update-events").exists())
+                .andDo(document("create-event"));
     }
 
     @Test

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -196,9 +196,10 @@ public class EventControllerTests {
                 .content(objectMapper.writeValueAsString(eventDto)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$[0].objectName").exists())
-                .andExpect(jsonPath("$[0].defaultMessage").exists())
-                .andExpect(jsonPath("$[0].code").exists());
+                .andExpect(jsonPath("errors[0].objectName").exists())
+                .andExpect(jsonPath("errors[0].defaultMessage").exists())
+                .andExpect(jsonPath("errors[0].code").exists())
+                .andExpect(jsonPath("_links.index").exists());
     }
 
 }

--- a/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
+++ b/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
@@ -1,0 +1,34 @@
+package com.example.springrestapi.index;
+
+import com.example.springrestapi.common.RestDocsConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@ActiveProfiles("test")
+public class IndexControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    public void index() throws Exception {
+        this.mockMvc.perform(get("/api/"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("_links.events").exists());
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+# \uD14C\uC2A4\uD2B8\uC6A9 \uB370\uC774\uD130\uC18C\uC2A4(H2 DB) \uC5F0\uACB0
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.hikari.jdbc-url=jdbc:h2:mem:testdb
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 스프링 HATEOAS 소개
- https://docs.spring.io/spring-hateoas/docs/current/reference/html/
- 링크 만드는 기능
    - 문자열 가지고 만들기
    - 컨트롤러와 메소드로 만들기
- 리소스 만드는 기능
    - 리소스: 데이터 + 링크
- 링크 찾아주는 기능
    - Traverson
    - LinkDiscoverers
- 링크
    - HREF
    - REL
        - self
        - profile
        - update-event
        - query-events

## 스프링 HATEOAS 적용

EvnetResource 만들기
- extends ResourceSupport의 문제
    - `@JsonUnwrapped`로 해결
    - extends Resource<T>로 해결

테스트할 것
- 응답에 HATEOA와 profile 관련 링크가 있는지 확인.
    - self (view)
    - update (만든 사람은 수정할 수 있으니까)
    - events (목록으로 가는 링크)

## 스프링 REST Docs 소개

- https://docs.spring.io/spring-restdocs/docs/2.0.2.RELEASE/reference/html5/

- REST Docs 코딩
    - andDo(document(“doc-name”, snippets))
    - snippets
        - links()
        - requestParameters() + parameterWithName()
        - pathParameters() + parametersWithName()
        - requestParts() + partWithname()
        - requestPartBody()
        - requestPartFields()
        - requestHeaders() + headerWithName()
        - requestFields() + fieldWithPath()
        - responseHeaders() + headerWithName()
        - responseFields() + fieldWithPath()
        - ...
    - Relaxed*
    - Processor
        - preprocessRequest(prettyPrint())
        - preprocessResponse(prettyPrint())
        - ...

Constraint
- https://github.com/spring-projects/spring-restdocs/blob/v2.0.2.RELEASE/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java

## 스프링 REST Docs 적용
REST Docs 자동 설정
- `@AutoConfigureRestDocs`

RestDocMockMvc 커스터마이징
- RestDocsMockMvcConfigurationCustomizer 구현한 빈 등록
- `@TestConfiguration`

테스트 할 것
- API 문서 만들기
    - 요청 본문 문서화
    - 응답 본문 문서화
    - 링크 문서화
        - profile 링크 추가
    - 응답 헤더 문서화

## 스프링 REST Docs: 링크, (Req, Res) 필드와 헤더 문서화

요청 필드 문서화
- requestFields() + fieldWithPath()
- responseFields() + fieldWithPath()
- requestHeaders() + headerWithName()
- responseHedaers() + headerWithName()
- links() + linkWithRel()

테스트 할 것
- API 문서 만들기
    - 요청 본문 문서화
    - 응답 본문 문서화
    - 링크 문서화
        - self
        - query-events
        - update-event
        - profile 링크 추가
    - 요청 헤더 문서화
    - 요청 필드 문서화
    - 응답 헤더 문서화
    - 응답 필드 문서화

Relaxed 접두어
- 장점: 문서 일부분만 테스트 할 수 있다.
- 단점: 정확한 문서를 생성하지 못한다.

## 스프링 REST Docs: 문서 빌드

스프링 REST Docs
- https://docs.spring.io/spring-restdocs/docs/2.0.2.RELEASE/reference/html5/
- pom.xml에 메이븐 플러그인 설정

```
            <plugin>
                <groupId>org.asciidoctor</groupId>
                <artifactId>asciidoctor-maven-plugin</artifactId>
                <version>1.5.3</version>
                <executions>
                    <execution>
                        <id>generate-docs</id>
                        <phase>prepare-package</phase>
                        <goals>
                            <goal>process-asciidoc</goal>
                        </goals>
                        <configuration>
                            <backend>html</backend>
                            <doctype>book</doctype>
                        </configuration>
                    </execution>
                </executions>
                <dependencies>
                    <dependency>
                        <groupId>org.springframework.restdocs</groupId>
                        <artifactId>spring-restdocs-asciidoctor</artifactId>
                        <version>2.0.2.RELEASE</version>
                    </dependency>
                </dependencies>
            </plugin>
            <plugin>
                <artifactId>maven-resources-plugin</artifactId>
                <version>2.7</version>
                <executions>
                    <execution>
                        <id>copy-resources</id>
                        <phase>prepare-package</phase>
                        <goals>
                            <goal>copy-resources</goal>
                        </goals>
                        <configuration>
                            <outputDirectory>
                                ${project.build.outputDirectory}/static/docs
                            </outputDirectory>
                            <resources>
                                <resource>
                                    <directory>
                                        ${project.build.directory}/generated-docs
                                    </directory>
                                </resource>
                            </resources>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```

- 템플릿 파일 추가
    - src/main/asciidoc/index.adoc

문서 생성하기
- mvn package
    - test
    - prepare-package :: process-asciidoc
    - prepare-package :: copy-resources
- 문서 확인
    - /docs/index.html

테스트 할 것
- API 문서 만들기
    - 요청 본문 문서화
    - 응답 본문 문서화
    - 링크 문서화
        - self
        - query-events
        - update-event
        - profile 링크 추가
    - 요청 헤더 문서화
    - 요청 필드 문서화
    - 응답 헤더 문서화
    - 응답 필드 문서화

## PostgreSQL 적용

테스트 할 때는 계속 H2를 사용해도 좋지만 애플리케이션 서버를 실행할 때 PostgreSQL을 사용하도록 변경하자.

/scripts.md 참고

- PostgreSQL 드라이버 의존성 추가
```
<dependency>
	<groupId>org.postgresql</groupId>
	<artifactId>postgresql</artifactId>
</dependency>
```

- 도커로 PostgreSQL 컨테이너 실행
```
docker run --name spring-restapi -p 5432:5432 -e POSTGRES_PASSWORD=pass -d postgres
```

- 도커 컨테이너에 들어가보기
```
docker exec -i -t spring-restapi bash
su - postgres
psql -d postgres -U postgres
\l
\dt
```

- 데이터소스 설정 (application.properties)
```
spring.datasource.username=postgres
spring.datasource.password=pass
spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
spring.datasource.driver-class-name=org.postgresql.Driver
```

- 하이버네이트 설정 (application.properties)
```
spring.jpa.hibernate.ddl-auto=create-drop
spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
spring.jpa.properties.hibernate.format_sql=true
logging.level.org.hibernate.SQL=DEBUG
logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
```

애플리케이션 설정과 테스트 설정 중복 어떻게 줄일 것인가?
- 프로파일과 `@ActiveProfiles` 활용

application-test.properties
```
spring.datasource.username=sa
spring.datasource.password=
spring.datasource.url=jdbc:h2:mem:testdb
spring.datasource.driver-class-name=org.h2.Driver
spring.datasource.hikari.jdbc-url=jdbc:h2:mem:testdb
spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
```

## 인덱스 핸들러 만들기

인덱스 핸들러
- 다른 리소스에 대한 링크 제공
- 문서화

```java
@GetMapping("/api")
public RepresentationModel index() {
    var index = new RepresentationModel();
    index.add(linkTo(EventController.class).withRel("events"));
    return index;
}
```

테스트 컨트롤러 리팩토링
- 중복 코드 제거

에러 리소스
- 인덱스로 가는 링크 제공