### PR TITLE
이벤트 조회 및 수정 REST API 개발

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,8 @@
 ## 학습 목차
 
 #### 1. [REST API](https://www.notion.so/REST-API-ee7b06bba2464fce8ff55bd042060d24)
+#### 2. [REST API 및 프로젝트 소개](https://github.com/Junhan0037/spring-restapi/pull/1)
+#### 3. [이벤트 생성 및 API 개발](https://github.com/Junhan0037/spring-restapi/pull/2)
+#### 4. [HATEOAS와 Self-Describtive Message 적용](https://github.com/Junhan0037/spring-restapi/pull/3)
 
 해당 repo는 [스프링 기반 REST API 개발 - 백기선](https://www.inflearn.com/course/spring_rest-api) 해당 강의를 듣고 정리한 REPO 입니다.

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -14,13 +14,11 @@ import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.Optional;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
@@ -71,6 +69,19 @@ public class EventController {
         var pagedResources = assembler.toModel(page, e -> new EventResource(e));
         pagedResources.add(new Link("/docs/index.html#resources-events-list").withRel("profile"));
         return ResponseEntity.ok(pagedResources);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity getEvent(@PathVariable Integer id) {
+        Optional<Event> optionalEvent = this.eventRepository.findById(id);
+        if (optionalEvent.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Event event = optionalEvent.get();
+        EventResource eventResource = new EventResource(event);
+        eventResource.add(new Link("/docs/index.html#resources-events-get").withRel("profile"));
+        return ResponseEntity.ok(eventResource);
     }
 
     private ResponseEntity badRequest(Errors errors) {

--- a/src/main/java/com/example/springrestapi/events/EventController.java
+++ b/src/main/java/com/example/springrestapi/events/EventController.java
@@ -3,12 +3,18 @@ package com.example.springrestapi.events;
 import com.example.springrestapi.common.ErrorsResource;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +63,14 @@ public class EventController {
 //        eventResource.add(selfLinkBuilder.withRel("update-events"));
 
         return ResponseEntity.created(createdUri).body(eventResource);
+    }
+
+    @GetMapping
+    public ResponseEntity queryEvents(Pageable pageable, PagedResourcesAssembler<Event> assembler) {
+        Page<Event> page = this.eventRepository.findAll(pageable);
+        var pagedResources = assembler.toModel(page, e -> new EventResource(e));
+        pagedResources.add(new Link("/docs/index.html#resources-events-list").withRel("profile"));
+        return ResponseEntity.ok(pagedResources);
     }
 
     private ResponseEntity badRequest(Errors errors) {

--- a/src/test/java/com/example/springrestapi/SpringRestapiApplicationTests.java
+++ b/src/test/java/com/example/springrestapi/SpringRestapiApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SpringRestapiApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }

--- a/src/test/java/com/example/springrestapi/common/BaseControllerTest.java
+++ b/src/test/java/com/example/springrestapi/common/BaseControllerTest.java
@@ -1,0 +1,31 @@
+package com.example.springrestapi.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Ignore;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@ActiveProfiles("test")
+@Ignore
+public class BaseControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected ModelMapper modelMapper;
+
+}

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -217,7 +217,7 @@ public class EventControllerTests {
         //given
         IntStream.range(0, 30).forEach(this::generateEvent);
 
-        //when
+        //when & then
         this.mockMvc.perform(get("/api/events")
                     .param("page", "1")
                     .param("size", "10")
@@ -232,12 +232,38 @@ public class EventControllerTests {
                 .andDo(document("query-document"));
     }
 
-    private void generateEvent(int index) {
+    @Test
+    @DisplayName("기존의 이벤트를 하나 조회하기")
+    public void getEvent() throws Exception {
+        //given
+        Event event = this.generateEvent(100);
+
+        //when & then
+        this.mockMvc.perform(get("/api/events/{id}", event.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("name").exists())
+                .andExpect(jsonPath("id").exists())
+                .andExpect(jsonPath("_links.self").exists())
+                .andExpect(jsonPath("_links.profile").exists())
+                .andDo(document("get-an-event"));
+    }
+
+    @Test
+    @DisplayName("없는 이벤트로 조회했을 때 404 응답받기")
+    public void getEvent404() throws Exception {
+        //when & then
+        this.mockMvc.perform(get("/api/events/11883"))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    private Event generateEvent(int index) {
         Event event = Event.builder()
                 .name("event" + index)
                 .description("test event")
                 .build();
-        this.eventRepository.save(event);
+        return this.eventRepository.save(event);
     }
 
 }

--- a/src/test/java/com/example/springrestapi/events/EventControllerTests.java
+++ b/src/test/java/com/example/springrestapi/events/EventControllerTests.java
@@ -1,21 +1,13 @@
 package com.example.springrestapi.events;
 
-import com.example.springrestapi.common.RestDocsConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.springrestapi.common.BaseControllerTest;
 import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
@@ -32,24 +24,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@ActiveProfiles("test")
-public class EventControllerTests {
-
-    @Autowired
-    MockMvc mockMvc;
-
-    @Autowired
-    ObjectMapper objectMapper;
+public class EventControllerTests extends BaseControllerTest {
 
     @Autowired
     EventRepository eventRepository;
-
-    @Autowired
-    ModelMapper modelMapper;
 
     @Autowired
     private WebApplicationContext ctx;

--- a/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
+++ b/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
@@ -1,29 +1,14 @@
 package com.example.springrestapi.index;
 
-import com.example.springrestapi.common.RestDocsConfiguration;
+import com.example.springrestapi.common.BaseControllerTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@ActiveProfiles("test")
-public class IndexControllerTest {
-
-    @Autowired
-    MockMvc mockMvc;
+public class IndexControllerTest extends BaseControllerTest {
 
     @Test
     public void index() throws Exception {

--- a/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
+++ b/src/test/java/com/example/springrestapi/index/IndexControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,6 +29,7 @@ public class IndexControllerTest {
     public void index() throws Exception {
         this.mockMvc.perform(get("/api/"))
                 .andExpect(status().isOk())
+                .andDo(print())
                 .andExpect(jsonPath("_links.events").exists());
     }
 


### PR DESCRIPTION
## Event 목록 조회 API

**페이징, 정렬**
- 스프링 데이터 JPA가 제공하는 Pageable

**Page<Event>에 안에 들어있는 Event 들은 리소스로 변경**
- PagedResourceAssembler<T> 사용하기

**[테스트 할 때 Pageable 파라미터 제공하는 방법](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#core.web)**
- page: 0부터 시작
- size: 기본값 20
- sort: property,property(,ASC|DESC)

**테스트 할 것**
- Event 목록 Page 정보와 함께 받기
    - content[0].id 확인
    - pageable 경로 확인
- Sort과 Paging 확인
    - 30개를 만들고, 10개 사이즈로 두번째 페이지 조회하면 이전, 다음 페이지로 가는 링크가 있어야 한다.
    - 이벤트 이름순으로 정렬하기
    - page 관련 링크
- Event를 EventResource로 변환해서 받기
    - 각 이벤트 마다 self
- 링크 확인
    - self
    - profile
    - (create)
- 문서화

## Event 조회 API

**조회하는 이벤트가 있는 경우 이벤트 리소스 확인**
- 링크
    - self
    - profile
    - (update)
- 이벤트 데이터

조회하는 이벤트가 없는 경우 404 응답 확인

## Events 수정 API

- 수정하려는 이벤트가 없는 경우 `404 NOT_FOUND`
- 입력 데이터 (데이터 바인딩)가 이상한 경우에 `400 BAD_REQUEST`
- 도메인 로직으로 데이터 검증 실패하면 `400 BAD_REQUEST` (권한이 충분하지 않은 경우에 `403 FORBIDDEN`)
- 정상적으로 수정한 경우에 이벤트 리소스 응답
    - 200 OK
    - 링크
    - 수정한 이벤트 데이터

## 테스트 코드 리팩토링

**여러 컨트롤러 간의 중복 코드 제거하기**
- 클래스 상속을 사용하는 방법
- `@Ignore` 애노테이션으로 테스트로 간주되지 않도록 설정
